### PR TITLE
feat(pagination): Pagination logic, controls and UIs

### DIFF
--- a/controllers/shop.js
+++ b/controllers/shop.js
@@ -6,14 +6,33 @@ const PDFDocument = require('pdfkit');
 const Product = require('../models/product');
 const Order = require('../models/order');
 
+// Will display items per page
+const ITEMS_PER_PAGE = 3;
+
 exports.getProducts = (req, res, next) => {
+  const page = +req.query.page || 1;
+  let totalItems;
+
   Product.find()
+    .countDocuments()
+    .then((numProducts) => {
+      totalItems = numProducts;
+
+      return Product.find()
+        .skip((page - 1) * ITEMS_PER_PAGE)
+        .limit(ITEMS_PER_PAGE);
+    })
     .then((products) => {
-      console.log(products);
       res.render('shop/product-list', {
         prods: products,
-        pageTitle: 'All Products',
-        path: '/products'
+        pageTitle: 'products',
+        path: '/products',
+        currentPage: page,
+        hasNextPage: ITEMS_PER_PAGE * page < totalItems,
+        hasPreviousPage: page > 1,
+        nextPage: page + 1,
+        previousPage: page - 1,
+        lastPage: Math.ceil(totalItems / ITEMS_PER_PAGE)
       });
     })
     .catch((error) => {
@@ -43,12 +62,29 @@ exports.getProduct = (req, res, next) => {
 };
 
 exports.getIndex = (req, res, next) => {
+  const page = +req.query.page || 1;
+  let totalItems;
+
   Product.find()
+    .countDocuments()
+    .then((numProducts) => {
+      totalItems = numProducts;
+
+      return Product.find()
+        .skip((page - 1) * ITEMS_PER_PAGE)
+        .limit(ITEMS_PER_PAGE);
+    })
     .then((products) => {
       res.render('shop/index', {
         prods: products,
         pageTitle: 'Shop',
-        path: '/'
+        path: '/',
+        currentPage: page,
+        hasNextPage: ITEMS_PER_PAGE * page < totalItems,
+        hasPreviousPage: page > 1,
+        nextPage: page + 1,
+        previousPage: page - 1,
+        lastPage: Math.ceil(totalItems / ITEMS_PER_PAGE)
       });
     })
     .catch((error) => {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -240,6 +240,26 @@ form {
   background: rgb(236, 200, 200);
 }
 
+.pagination {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.pagination a {
+  text-decoration: none;
+  color: #106dd0;
+  padding: 0.5rem;
+  border: 1px solid #106dd0;
+  margin: 0 1rem;
+}
+
+.pagination a:hover,
+.pagination a:active,
+.pagination a.active {
+  background: #106dd0;
+  color: white
+}
+
 @media (min-width: 768px) {
   .main-header__nav {
     display: flex;

--- a/views/includes/pagination.ejs
+++ b/views/includes/pagination.ejs
@@ -1,0 +1,16 @@
+<selection class="pagination">
+  <% if(currentPage !== 1 && previousPage !== 1) { %>
+  <a href="?page=1">1</a>
+  <% } %> <% if(hasPreviousPage) { %>
+  <a href="?page=<%= previousPage %>"><%= previousPage %></a>
+  <% } %>
+
+  <a href="?page=<%= currentPage %>" class="active"><%= currentPage %></a>
+
+  <% if(hasNextPage) { %>
+  <a href="?page=<%= nextPage %>"><%= nextPage %></a>
+  <% } %> <% if(lastPage !== currentPage && nextPage !== lastPage) { %>
+  <a href="?page=<%= lastPage %>"><%= lastPage %></a>
+
+  <% } %>
+</selection>

--- a/views/shop/index.ejs
+++ b/views/shop/index.ejs
@@ -30,6 +30,9 @@
                     </article>
                 <% } %>
             </div>
+            
+            <%- include('../includes/pagination.ejs', { currentPage, nextPage, previousPage, lastPage, hasNextPage, hasPreviousPage }) %>
+
         <% } else { %>
             <h1>No Products Found!</h1>
         <% } %>

--- a/views/shop/product-list.ejs
+++ b/views/shop/product-list.ejs
@@ -35,6 +35,9 @@
                             </article>
                             <% } %>
                     </div>
+                    
+                    <%- include('../includes/pagination.ejs', { currentPage, nextPage, previousPage, lastPage, hasNextPage, hasPreviousPage }) %>
+
                     <% } else { %>
                         <h1>No Products Found!</h1>
                         <% } %>


### PR DESCRIPTION
# Changes 
- Adding pagination links
- Retrieving a chunk of data
- Pagination on the server side
- Dynamic pagination buttons
- Reusable pagination logic and controls


# Related documentation
When using MongoDB, you can use skip() and limit() as shown in the last lecture.

But how would that work in SQL?

Here's how you would implement pagination in SQL code: https://stackoverflow.com/questions/3799193/mysql-data-best-way-to-implement-paging

To quickly sum it up: The LIMIT command allows you to restrict the amount of data points you fetch, it's your limit() equivalent. Combined with the OFFSET command (which replaces skip()), you can control how many items you want to fetch and how many you want to skip.

When using Sequelize, the official docs describe how to add pagination: https://sequelize.org/master/manual/model-querying-basics.html